### PR TITLE
Animation Track Interpolation/Blending toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ https://github.com/user-attachments/assets/2eaf3977-77ec-4bb1-9214-27dd26975533
 - Ability to control the alpha channel for individual instances.  Also includes easy fade in/out tweened functions.
 - Ability to set a unique fps speed per animation track.
 - Ability to restart the non-looping animation tracks for individual instances.
+- Ability to set animation interpolation (blending) for each animation track. Suggested by: @theHoodaloo
 - Visual Shaders are supported so you can also freely apply your own shader logic while still having VAT animations.
 - All the `MultiMeshInstance3D` features such as a unique transform (scale, rotation, and position) per instance.
 - Works on all renderers, and on HTML builds.
@@ -155,8 +156,9 @@ extends Resource
 var name: String
 var startFrame: int
 var endFrame: int
-var framerate: int
 var isLooping: bool
+var isBlended: bool
+var framerate: int
 ```
 
 To get the `VATAnimationTrack` object from an instance:
@@ -190,9 +192,10 @@ The inherited `MultiMeshInstance3D` `custom_data` is used by this plugin and ins
 
 The inherited `MultiMeshInstance3D` `color_instance` is used by this plugin and instanced shader.  Here is how it is used:
 
-- `color.r` = **is_looping** 1.0 = true, 0.0 = false
+- `color.r` = **use_looping** 1.0 = true, 0.0 = false
 - `color.g` = **timestamp** used to keep track of when an animation was set or the one_shot has been reset.
 - `color.b` = **animation frame rate**: must be greater than zero
+- `color.a` = **use_blended**: 1.0 = true, 0.0 = false
 
 ## Vertex Animation Shader
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ https://github.com/user-attachments/assets/2eaf3977-77ec-4bb1-9214-27dd26975533
 - Ability to control the alpha channel for individual instances.  Also includes easy fade in/out tweened functions.
 - Ability to set a unique fps speed per animation track.
 - Ability to restart the non-looping animation tracks for individual instances.
-- Ability to set animation interpolation (blending) for each animation track. Suggested by: @theHoodaloo
+- Ability to set animation interpolation (blending) for each animation track. Suggested by: [@theHoodaloo](https://github.com/antzGames/Godot_Vertex_Animation_Textures_Plugin/issues/7)
 - Visual Shaders are supported so you can also freely apply your own shader logic while still having VAT animations.
 - All the `MultiMeshInstance3D` features such as a unique transform (scale, rotation, and position) per instance.
 - Works on all renderers, and on HTML builds.

--- a/addons/godot_vat/plugin.cfg
+++ b/addons/godot_vat/plugin.cfg
@@ -5,5 +5,5 @@ description="Godot 4.5+ Vertex Animation Textures Plugin
 
 Extends MultiMeshInstance3D to support vertex animations."
 author="Antz"
-version="0.1.4"
+version="0.1.5"
 script="godot_vat.gd"

--- a/addons/godot_vat/shaders/vat_multiple_anims.gdshader
+++ b/addons/godot_vat/shaders/vat_multiple_anims.gdshader
@@ -17,11 +17,11 @@ It has total of 4 floats. All renderers supported
 		alpha of mesh: used to fade in/out a unique instance
 
 		
-Instanced COLOR is used for looping / non-looping (also called one_shot) animations.
+Instanced COLOR is used for interpolation, looping / non-looping (also called one_shot) animations.
 It has total of 4 floats. All renderers supported.
 
 	Red channel:
-		is_looping: 1.0 = true, 0.0 = false
+		use_looping: 1.0 = true, 0.0 = false
 
 	Green channel:
 		timestamp:
@@ -29,10 +29,11 @@ It has total of 4 floats. All renderers supported.
 			if non-lopping - Tells the shader when the one_shot has been reset.
 
 	Blue channel: 
-			animation frame rate - must be greater than 0
+		animation frame rate - must be greater than 0
 	
 	Alpha channel:
-			is animation belnded/interpolated
+		use_blended: 1.0 = true, 0.0 = false
+		Animation track blend/interpolation, suggested by: @theHoodaloo
 */
 
 shader_type spatial;
@@ -72,8 +73,7 @@ void vertex(){
 	color_data = COLOR;
 
 	float use_looping = color_data.r;
-	float use_blended = color_data.a;
-	
+	float use_blended = color_data.a; // Suggested by: @theHoodaloo
 	float timestamp = color_data.g;
 	
 	float start_frame = custom_data.g;

--- a/addons/godot_vat/shaders/vat_multiple_anims.gdshader
+++ b/addons/godot_vat/shaders/vat_multiple_anims.gdshader
@@ -31,7 +31,8 @@ It has total of 4 floats. All renderers supported.
 	Blue channel: 
 			animation frame rate - must be greater than 0
 	
-	Alpha channel: not used
+	Alpha channel:
+			is animation belnded/interpolated
 */
 
 shader_type spatial;
@@ -70,7 +71,9 @@ void vertex(){
 	custom_data = INSTANCE_CUSTOM;
 	color_data = COLOR;
 
-	bool is_looping = color_data.r > 0.5; // 1.0 = true, 0.0 = false
+	float use_looping = color_data.r;
+	float use_blended = color_data.a;
+	
 	float timestamp = color_data.g;
 	
 	float start_frame = custom_data.g;
@@ -85,21 +88,35 @@ void vertex(){
 	num_frames = clamp(num_frames, 0.0001, 8192.0);
 
 	float time_scale_normalized = (TIME - timestamp) * (speed / num_frames);
-	float frame_time;
-	float current_frame;
-	float frame_ceil;
+	
+	float loop_time  = mod(time_scale_normalized, 1.0);
+	float frame_time = mix(time_scale_normalized, loop_time, use_looping);
+
+	float frame_progress        = frame_time * num_frames;
+	float frame_progress_offset = frame_progress + frame_offset;
 		
-	if (is_looping) {
-		frame_time = mod(time_scale_normalized, 1.0);
-		current_frame = start_frame + mod((frame_time * num_frames) + frame_offset, num_frames) + 1.0;
-		if (current_frame > end_frame) current_frame = start_frame;
-		frame_ceil = float(int(ceil(current_frame) - start_frame) % frame_count) + start_frame;
-	} else {
-		frame_time = time_scale_normalized;
-		current_frame = start_frame + (frame_time * num_frames) + frame_offset + 1.0;
-		if (current_frame >= end_frame) current_frame = end_frame;
-		frame_ceil = clamp(ceil(current_frame), start_frame, end_frame);
-	}
+	float stop_frame = start_frame + floor(frame_progress);
+
+	float blend_frame = start_frame + mix(
+		frame_progress_offset + 1.0,
+		mod(frame_progress_offset, num_frames) + 1.0,
+		use_looping
+	);
+		
+	float current_frame_raw = mix(stop_frame, blend_frame, use_blended);
+	float ceil_frame        = ceil(current_frame_raw);
+
+	float current_frame = mix(
+		clamp(current_frame_raw, start_frame, end_frame),
+		mix(current_frame_raw, start_frame, step(end_frame, current_frame_raw)),
+		use_looping
+	);
+
+	float frame_ceil = mix(
+		clamp(ceil_frame, start_frame, end_frame),
+		float(int(ceil_frame - start_frame) % frame_count) + start_frame,
+		use_looping
+	);
 		
 	ivec2 tex_size = textureSize(offset_map, 0);
 	float pixel_size = 1.0 / float(tex_size.y);

--- a/addons/godot_vat/src/vat_animation_track.gd
+++ b/addons/godot_vat/src/vat_animation_track.gd
@@ -18,16 +18,21 @@ extends Resource
 ## like a death animation, or does it loop?
 @export var isLooping: bool = true
 
+## Is the animation track only to be played once,[br]
+## like a death animation, or does it loop?
+@export var isBlended: bool = true
+
 ## Each animation track can have it own unique fps.[br]
 ## If set to 0, then it will be replaced by [member VATMultiMeshInstance3D.default_fps].
 @export_range(0, 120) var framerate: int
 
-func set_track(name_in: String, start_in: int, end_in: int, framerate_in: int, loop: bool):
+func set_track(name_in: String, start_in: int, end_in: int, framerate_in: int, loop: bool, blend: bool):
 	name = name_in
 	startFrame = start_in
 	endFrame = end_in
 	framerate = framerate_in
 	isLooping = loop
+	isBlended = blend
 	
 func _to_string() -> String:
-	return str("Animation Track Name: ",name, "   startFrame: ", startFrame, "    endFrame: ", endFrame, "   framerate: ", framerate, "   isLooping: ", isLooping)
+	return str("Animation Track Name: ",name, "   startFrame: ", startFrame, "    endFrame: ", endFrame, "   framerate: ", framerate, "   isLooping: ", isLooping, "   isBlended: ", isBlended)

--- a/addons/godot_vat/vat_multi_mesh_instance_3d.gd
+++ b/addons/godot_vat/vat_multi_mesh_instance_3d.gd
@@ -71,7 +71,7 @@ func _ready() -> void:
 		multimesh.instance_count = 0
 		multimesh.transform_format = MultiMesh.TRANSFORM_3D
 		multimesh.use_custom_data = true # offsets, start/end frame, alpha
-		multimesh.use_colors = true # isLooping, timestamp
+		multimesh.use_colors = true # isLooping, timestamp, isBlended
 		multimesh.instance_count = instance_count
 		physics_interpolation_mode = Node.PHYSICS_INTERPOLATION_MODE_OFF # becasue Godot interpolates custom_data, which we do not want
 	else:
@@ -97,7 +97,7 @@ func _ready() -> void:
 			if vat_anim.framerate == 0: vat_anim.framerate = default_fps
 			if !vat_anim.name or vat_anim.name.is_empty():
 				vat_anim.name = str("Track", i)
-			print_rich(str("  🎞️ Animation track: [color=yellow]", vat_anim.name, "[/color]   Start/End Frames: [color=yellow]", vat_anim.startFrame , "-", vat_anim.endFrame, "[/color]   isLooping: [color=yellow]", vat_anim.isLooping ,"[/color]   FPS: [color=yellow]", vat_anim.framerate,"[/color]"))
+			print_rich(str("  🎞️ Animation track: [color=yellow]", vat_anim.name, "[/color]   Start/End Frames: [color=yellow]", vat_anim.startFrame , "-", vat_anim.endFrame, "[/color]   isLooping: [color=yellow]", vat_anim.isLooping ,"[/color]   isBlended: [color=yellow]", vat_anim.isBlended , "[/color]   FPS: [color=yellow]", vat_anim.framerate,"[/color]"))
 			i += 1
 
 		print_rich("[color=cyan]Animation configuration completed.[/color]")
@@ -128,7 +128,7 @@ func update_instance_track(instance_id: int, track_number: int) -> void:
 	custom_data.b = vat_animation_tracks[track_number].endFrame
 	multimesh.set_instance_custom_data(instance_id, custom_data)
 		
-	reset_one_shot(instance_id)
+	reset_one_shot(instance_id)  # will also update isBlended
 
 ## Updates the current instance_id with the provided alpha (0..1)
 func update_instance_alpha(instance_id: int, alpha: float) -> void:
@@ -292,7 +292,12 @@ func reset_one_shot(instance_id: int):
 		custom_color.r = 1.0
 	else:
 		custom_color.r = 0.0
-	
+		
+	if anim.isBlended:
+		custom_color.a = 1.0
+	else:
+		custom_color.a = 0.0
+		
 	custom_color.g = get_current_timestamp()
 	custom_color.b = anim.framerate
 	

--- a/demo/skeleton_track_change.tscn
+++ b/demo/skeleton_track_change.tscn
@@ -32,7 +32,7 @@ use_colors = true
 use_custom_data = true
 instance_count = 1
 mesh = ExtResource("4_acrxm")
-buffer = PackedFloat32Array(0, 8e-45, 1e-45, 0, 1e-44, 8e-45, 1e-45, 7e-45, 3e-45, 1e-45, 8e-45, 7e-45, 3e-45, 6e-45, 4e-45, 3e-45, 7e-45, 6e-45, 0.07888999, 0.07888999)
+buffer = PackedFloat32Array(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
 
 [sub_resource type="Resource" id="Resource_5fsja"]
 script = ExtResource("6_36v5s")
@@ -121,6 +121,7 @@ name = "Track10"
 startFrame = 390
 endFrame = 475
 isLooping = false
+isBlended = false
 framerate = 16
 metadata/_custom_type_script = "uid://b7dau4o26vdnl"
 

--- a/demo/src/vat_instanced_track.gd
+++ b/demo/src/vat_instanced_track.gd
@@ -9,7 +9,7 @@ func _ready() -> void:
 	mesh_floor.mesh.size = Vector2(200,200) 
 	
 	for track in vat_multi_mesh_instance_3d.vat_animation_tracks:
-		track_select.add_item(str(track.name,"   FPS:", track.framerate, "   isLooping:", track.isLooping))
+		track_select.add_item(str(track.name,"   FPS:", track.framerate, "   isLooping:", track.isLooping, "   isBlended:", track.isBlended))
 		
 	_on_track_select_item_selected(0)
 

--- a/project.godot
+++ b/project.godot
@@ -20,7 +20,7 @@ compatibility/default_parent_skeleton_in_mesh_instance_3d=true
 [application]
 
 config/name="Godot_VAT_Plugin"
-config/version="0.1.4"
+config/version="0.1.5"
 run/main_scene="uid://cmhtwdpo7atr4"
 config/features=PackedStringArray("4.7", "GL Compatibility")
 boot_splash/image="res://demo/assets/images/AntzBanner1.png"


### PR DESCRIPTION
Completes enhancment https://github.com/antzGames/Godot_Vertex_Animation_Textures_Plugin/issues/7 suggested by [@theHoodaloo](https://github.com/theHoodaloo)

Animation tracks can have its interpolation (blending) toggled.

<img width="752" height="840" alt="image" src="https://github.com/user-attachments/assets/2e539c4c-dd34-4f24-883a-5916fc0ba191" />
